### PR TITLE
'setup.py egg_info' fails because of trailing slash in the manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include README.rst
 recursive-include flatblocks/locale *
-recursive-include flatblocks/templates/flatblocks/ *.html
+recursive-include flatblocks/templates/flatblocks *.html
 exclude .gitignore


### PR DESCRIPTION
`setup.py egg_info` failed for me because of a trailing slash in the manifest. Not sure why this hasn't been a problem before, I guess either Windows is more picky or it's Python 2.7. But from what I see, no trailing slash seems to be the standard here anyway.

After this trivial change, I could install django-flatblocks (via pip through django-mingus).

The original stacktrace was as follows:
    D:\django-flatblocks>setup.py egg_info
    running egg_info
    writing django_flatblocks.egg-info\PKG-INFO
    writing top-level names to django_flatblocks.egg-info\top_level.txt
    writing dependency_links to django_flatblocks.egg-info\dependency_links.txt
    reading manifest file 'django_flatblocks.egg-info\SOURCES.txt'
    reading manifest template 'MANIFEST.in'
    Traceback (most recent call last):
      File "setup.py", line 32, in <module>
        zip_safe = False,
      File "c:\Program Files (x86)\Python 2.7\Lib\distutils\core.py", line 152, in setup
        dist.run_commands()
      File "c:\Program Files (x86)\Python 2.7\Lib\distutils\dist.py", line 953, in run_commands
        self.run_command(cmd)
      File "c:\Program Files (x86)\Python 2.7\Lib\distutils\dist.py", line 972, in run_command
        cmd_obj.run()
      File "C:\Program Files (x86)\Python 2.7\Lib\site-packages\setuptools-0.6c11-py2.7.egg\setuptools\command\egg_info.py", line 177, in run
      File "C:\Program Files (x86)\Python 2.7\Lib\site-packages\setuptools-0.6c11-py2.7.egg\setuptools\command\egg_info.py", line 252, in find_sources
      File "C:\Program Files (x86)\Python 2.7\Lib\site-packages\setuptools-0.6c11-py2.7.egg\setuptools\command\egg_info.py", line 308, in run
      File "C:\Program Files (x86)\Python 2.7\Lib\site-packages\setuptools-0.6c11-py2.7.egg\setuptools\command\sdist.py", line 157, in read_template
      File "c:\Program Files (x86)\Python 2.7\Lib\distutils\command\sdist.py", line 315, in read_template
        self.filelist.process_template_line(line)
      File "c:\Program Files (x86)\Python 2.7\Lib\distutils\filelist.py", line 118, in process_template_line
        action, patterns, dir, dir_pattern = self._parse_template_line(line)
      File "c:\Program Files (x86)\Python 2.7\Lib\distutils\filelist.py", line 97, in _parse_template_line
        dir = convert_path(words[1])
      File "c:\Program Files (x86)\Python 2.7\Lib\distutils\util.py", line 202, in convert_path
        raise ValueError, "path '%s' cannot end with '/'" % pathname
    ValueError: path 'flatblocks/templates/flatblocks/' cannot end with '/'
